### PR TITLE
chore: rename Equilibria to XEQMLabs, update filenames and seed nodes

### DIFF
--- a/src/blockchain_utilities/blockchain_ancestry.cpp
+++ b/src/blockchain_utilities/blockchain_ancestry.cpp
@@ -374,7 +374,7 @@ int main(int argc, char* argv[]) {
         return 1;
 
     if (command_line::get_arg(vm, command_line::arg_help)) {
-        std::cout << "Equilibria '" << OXEN_RELEASE_NAME << "' (v" << OXEN_VERSION_FULL << ")\n\n";
+        std::cout << "XEQMLabs '" << OXEN_RELEASE_NAME << "' (v" << OXEN_VERSION_FULL << ")\n\n";
         std::cout << desc_options << std::endl;
         return 1;
     }

--- a/src/blockchain_utilities/blockchain_depth.cpp
+++ b/src/blockchain_utilities/blockchain_depth.cpp
@@ -85,7 +85,7 @@ int main(int argc, char* argv[]) {
         return 1;
 
     if (command_line::get_arg(vm, command_line::arg_help)) {
-        std::cout << "Equilibria '" << OXEN_RELEASE_NAME << "' (v" << OXEN_VERSION_FULL << ")\n\n";
+        std::cout << "XEQMLabs '" << OXEN_RELEASE_NAME << "' (v" << OXEN_VERSION_FULL << ")\n\n";
         std::cout << desc_options << std::endl;
         return 1;
     }

--- a/src/blockchain_utilities/blockchain_export.cpp
+++ b/src/blockchain_utilities/blockchain_export.cpp
@@ -85,7 +85,7 @@ int main(int argc, char* argv[]) {
         return 1;
 
     if (command_line::get_arg(vm, command_line::arg_help)) {
-        std::cout << "Equilibria '" << OXEN_RELEASE_NAME << "' (v" << OXEN_VERSION_FULL << ")\n\n";
+        std::cout << "XEQMLabs '" << OXEN_RELEASE_NAME << "' (v" << OXEN_VERSION_FULL << ")\n\n";
         std::cout << desc_options << std::endl;
         return 1;
     }

--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -572,7 +572,7 @@ int main(int argc, char* argv[]) {
     db_batch_size = command_line::get_arg(vm, arg_batch_size);
 
     if (command_line::get_arg(vm, command_line::arg_help)) {
-        std::cout << "Equilibria '" << OXEN_RELEASE_NAME << "' (v" << OXEN_VERSION_FULL << ")\n\n";
+        std::cout << "XEQMLabs '" << OXEN_RELEASE_NAME << "' (v" << OXEN_VERSION_FULL << ")\n\n";
         std::cout << desc_options << std::endl;
         return 1;
     }

--- a/src/blockchain_utilities/blockchain_prune.cpp
+++ b/src/blockchain_utilities/blockchain_prune.cpp
@@ -572,7 +572,7 @@ int main(int argc, char* argv[]) {
         return 1;
 
     if (command_line::get_arg(vm, command_line::arg_help)) {
-        std::cout << "Equilibria '" << OXEN_RELEASE_NAME << "' (v" << OXEN_VERSION_FULL << ")\n\n";
+        std::cout << "XEQMLabs '" << OXEN_RELEASE_NAME << "' (v" << OXEN_VERSION_FULL << ")\n\n";
         std::cout << desc_options << std::endl;
         return 1;
     }

--- a/src/blockchain_utilities/blockchain_prune_known_spent_data.cpp
+++ b/src/blockchain_utilities/blockchain_prune_known_spent_data.cpp
@@ -138,7 +138,7 @@ int main(int argc, char* argv[]) {
         return 1;
 
     if (command_line::get_arg(vm, command_line::arg_help)) {
-        std::cout << "Equilibria '" << OXEN_RELEASE_NAME << "' (v" << OXEN_VERSION_FULL << ")\n\n";
+        std::cout << "XEQMLabs '" << OXEN_RELEASE_NAME << "' (v" << OXEN_VERSION_FULL << ")\n\n";
         std::cout << desc_options << std::endl;
         return 1;
     }

--- a/src/blockchain_utilities/blockchain_stats.cpp
+++ b/src/blockchain_utilities/blockchain_stats.cpp
@@ -97,7 +97,7 @@ int main(int argc, char* argv[]) {
         return 1;
 
     if (command_line::get_arg(vm, command_line::arg_help)) {
-        std::cout << "Equilibria '" << OXEN_RELEASE_NAME << "' (v" << OXEN_VERSION_FULL << ")\n\n";
+        std::cout << "XEQMLabs '" << OXEN_RELEASE_NAME << "' (v" << OXEN_VERSION_FULL << ")\n\n";
         std::cout << desc_options << std::endl;
         return 1;
     }

--- a/src/blockchain_utilities/blockchain_usage.cpp
+++ b/src/blockchain_utilities/blockchain_usage.cpp
@@ -116,7 +116,7 @@ int main(int argc, char* argv[]) {
         return 1;
 
     if (command_line::get_arg(vm, command_line::arg_help)) {
-        std::cout << "Equilibria '" << OXEN_RELEASE_NAME << "' (v" << OXEN_VERSION_FULL << ")\n\n";
+        std::cout << "XEQMLabs '" << OXEN_RELEASE_NAME << "' (v" << OXEN_VERSION_FULL << ")\n\n";
         std::cout << desc_options << std::endl;
         return 1;
     }

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -170,7 +170,7 @@ using MAXIMUM_ACCEPTABLE_STAKE = std::ratio<101, 100>;
 // precision of HF19+ registrations (i.e. to a percentage with two decimal places of precision).
 inline constexpr uint64_t STAKING_FEE_BASIS = 10'000;
 
-// Equilibria Horizon: Maximum operator fee is 10% (1,000 basis points out of 10,000)
+// XEQMLabs Horizon: Maximum operator fee is 10% (1,000 basis points out of 10,000)
 inline constexpr uint64_t MAX_OPERATOR_FEE_BASIS = 1'000;
 
 // We calculate and store batch rewards in thousanths of atomic OXEN/SESH, to reduce the size of
@@ -226,14 +226,14 @@ namespace p2p {
 // filename constants:
 inline const std::filesystem::path DATA_DIRNAME{
 #ifdef _WIN32
-        u8"equilibria"  // Buried in some windows filesystem maze location
+        u8"xeqmlabs"  // Buried in some windows filesystem maze location
 #else
-        u8".equilibria"  // ~/.equilibria
+        u8".xeqmlabs"  // ~/.xeqmlabs
 #endif
 };
-inline const std::filesystem::path CONF_FILENAME{u8"equilibria.conf"};
-inline const std::filesystem::path SOCKET_FILENAME{u8"equilibria.sock"};
-inline const std::filesystem::path LOG_FILENAME{u8"equilibria.log"};
+inline const std::filesystem::path CONF_FILENAME{u8"xeqm.conf"};
+inline const std::filesystem::path SOCKET_FILENAME{u8"xeqm.sock"};
+inline const std::filesystem::path LOG_FILENAME{u8"xeqm.log"};
 inline const std::filesystem::path POOLDATA_FILENAME{u8"poolstate.bin"};
 inline const std::filesystem::path BLOCKCHAINDATA_FILENAME{u8"data.mdb"};
 inline const std::filesystem::path BLOCKCHAINDATA_LOCK_FILENAME{u8"lock.mdb"};

--- a/src/daemon/command_server.cpp
+++ b/src/daemon/command_server.cpp
@@ -136,7 +136,7 @@ void command_server::init_commands(cryptonote::rpc::core_rpc_server* rpc_server)
             "start_mining",
             [this](const auto& x) { return m_parser.start_mining(x); },
             "start_mining <addr> [threads=N] [num_blocks=B]",
-            "Start mining for specified address, primarily for debug and testing purposes as Equilibria "
+            "Start mining for specified address, primarily for debug and testing purposes as XEQMLabs "
             "is proof-of-stake. Defaults to 1 thread. When num_blocks is set, continue mining "
             "until the blockchain reaches height (current + B).");
     m_command_lookup.set_handler(
@@ -336,7 +336,7 @@ bool command_server::help(const std::vector<std::string>& args) {
 
 std::string command_server::get_commands_str() {
     std::stringstream ss;
-    ss << "Equilibria '" << OXEN_RELEASE_NAME << "' (v" << OXEN_VERSION_FULL << ")" << std::endl;
+    ss << "XEQMLabs '" << OXEN_RELEASE_NAME << "' (v" << OXEN_VERSION_FULL << ")" << std::endl;
     ss << "Commands:\n";
     m_command_lookup.for_each([&ss](const std::string&,
                                     const std::string& usage,

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -486,13 +486,13 @@ void daemon::cleanup_socket_files() {
         }
         
         // Paths to socket files
-        std::string equilibria_sock = (std::filesystem::path(data_dir) / "equilibria.sock").string();
+        std::string xeqmlabs_sock = (std::filesystem::path(data_dir) / "xeqm.sock").string();
         std::string lokid_sock = (std::filesystem::path(data_dir) / "lokid.sock").string();
         
         // Remove socket files if they exist
-        if (std::filesystem::exists(equilibria_sock)) {
-            log::info(logcat, "Removing stale socket file: {}", equilibria_sock);
-            std::filesystem::remove(equilibria_sock);
+        if (std::filesystem::exists(xeqmlabs_sock)) {
+            log::info(logcat, "Removing stale socket file: {}", xeqmlabs_sock);
+            std::filesystem::remove(xeqmlabs_sock);
         }
         
         if (std::filesystem::exists(lokid_sock)) {

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -68,7 +68,7 @@ constexpr auto YELLOW = "\033[33;1m";
 constexpr auto CYAN = "\033[36;1m";
 
 const std::string coloured_oxen_release =
-        "{}Equilibria '{}' (v{}){}"_format(CYAN, OXEN_RELEASE_NAME, OXEN_VERSION_FULL, RESET);
+        "{}XEQMLabs '{}' (v{}){}"_format(CYAN, OXEN_RELEASE_NAME, OXEN_VERSION_FULL, RESET);
 }  // namespace
 
 int main(int argc, char const* argv[]) {
@@ -337,7 +337,7 @@ int main(int argc, char const* argv[]) {
         Log::info(
                 globallogcat,
                 fg(fmt::terminal_color::cyan) | fmt::emphasis::bold,
-                "Equilibria '{}' (v{})",
+                "XEQMLabs '{}' (v{})",
                 OXEN_RELEASE_NAME,
                 OXEN_VERSION_FULL);
 
@@ -386,7 +386,7 @@ int main(int argc, char const* argv[]) {
 
         Log::info(logcat, "Moving from main() into the daemonize now.");
 
-        return daemonizer::daemonize<daemonize::daemon>("Equilibria Daemon", argc, argv, std::move(vm))
+        return daemonizer::daemonize<daemonize::daemon>("XEQMLabs Daemon", argc, argv, std::move(vm))
                      ? 0
                      : 1;
     } catch (std::exception const& ex) {

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -2442,7 +2442,7 @@ bool rpc_command_executor::prepare_registration(bool force_registration) {
 
     fmt::print(
             "\n\n\x1b[33;1m"
-            "Equilibria Service Node Registration\n"
+            "XEQMLabs Service Node Registration\n"
             "------------------------------\n"
             "Service Node Pubkey: \x1b[32;1m{}\x1b[33;1m\n"
             "Staking requirement: {} from up to {} contributors\n\n",

--- a/src/oxen_economy.h
+++ b/src/oxen_economy.h
@@ -53,7 +53,7 @@ static_assert(SN_REWARD_HF19 + FOUNDATION_REWARD_HF19 == 20'650'000'000);  // 20
 //
 // -------------------------------------------------------------------------------------------------
 
-// Equilibria Horizon: Full stake requirement is 200,000 XEQ
+// XEQMLabs Horizon: Full stake requirement is 200,000 XEQ
 inline constexpr uint64_t OXEN_STAKING_REQUIREMENT = 200'000 * COIN;
 // testnet/devnet/fakenet have always had a fixed 100 OXEN staking requirement:
 inline constexpr uint64_t OXEN_STAKING_REQUIREMENT_TESTNET = 100'000 * COIN;
@@ -71,7 +71,7 @@ inline constexpr uint64_t SESH_STAKING_REQUIREMENT_LOCALDEV = 100'000 * COIN;
 // annual simple payout rate (= 14% compounding rate).
 inline constexpr uint64_t ETH_BLS_INITIAL_REWARD = 40000000'000000000 * 151 / 1000 / 365 / 720;
 
-// Equilibria Horizon: Minimum operator contribution is 50% of staking requirement (100,000 XEQ)
+// XEQMLabs Horizon: Minimum operator contribution is 50% of staking requirement (100,000 XEQ)
 constexpr uint64_t MINIMUM_OPERATOR_CONTRIBUTION(uint64_t staking_requirement) {
     return staking_requirement / 2;
 }

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -245,8 +245,8 @@ struct GET_HEIGHT : PUBLIC, LEGACY, NO_ARGS {
 ///         - `"pulse"` -- the service node missed too many recent pulse votes
 ///         - `"storage"` -- the service node's storage server was unreachable for too long
 ///         - `"lokinet"` -- the service node's lokinet router was unreachable for too long
-///         - `"timecheck"` -- the service node's equilibriad was not reachable for too many recent
-///           time synchronization checks.  (This generally means equilibriad's quorumnet port is not
+///         - `"timecheck"` -- the service node's xeqmlabsd was not reachable for too many recent
+///           time synchronization checks.  (This generally means xeqmlabsd's quorumnet port is not
 ///           reachable).
 ///         - `"timesync"` -- the service node's clock was too far out of sync
 ///         The list is omitted entirely if there are no reasons at all or if there are no reasons
@@ -1221,7 +1221,7 @@ struct IN_PEERS : LEGACY {
 ///   the blockchain height is at or above the requested hardfork).
 /// - `earliest_height` -- Block height at which the hard fork will become enabled.
 /// - `last_height` -- The last block height at which this hard fork will be active; will be
-///   omitted if this equilibriad is not aware of any following hard fork.
+///   omitted if this xeqmlabsd is not aware of any following hard fork.
 ///
 /// Example input:
 ///
@@ -1784,7 +1784,7 @@ void to_json(nlohmann::json& j, const GET_QUORUM_STATE::quorum_for_height& q);
 /// RPC: service_node/get_service_node_registration_cmd_raw
 ///
 /// Generates a signed service node registration command for use in the operator's Oxen wallet.
-/// This endpoint is primarily for internal use by the `equilibriad prepare_registration` command.
+/// This endpoint is primarily for internal use by the `xeqmlabsd prepare_registration` command.
 ///
 /// Inputs:
 ///
@@ -1961,8 +1961,8 @@ struct GET_SERVICE_PRIVKEYS : NO_ARGS {
 ///     - `0x02` - Missed too many checkpoint votes
 ///     - `0x04` - Missed too many pulse blocks
 ///     - `0x08` - Storage server unreachable
-///     - `0x10` - equilibriad quorumnet unreachable for timesync checks
-///     - `0x20` - equilibriad system clock is too far off
+///     - `0x10` - xeqmlabsd quorumnet unreachable for timesync checks
+///     - `0x20` - xeqmlabsd system clock is too far off
 ///     - `0x40` - Lokinet unreachable
 ///     - other bit values are reserved for future use.
 ///   - `last_decommission_reason_consensus_any` -- The reason for the last decommission as voted
@@ -2036,7 +2036,7 @@ struct GET_SERVICE_PRIVKEYS : NO_ARGS {
 ///     uptime proof yet.
 ///   - `storage_lmq_port` -- The port number associated with the storage server (oxenmq interface);
 ///     omitted if we have no uptime proof yet.
-///   - `quorumnet_port` -- The port for direct SN-to-SN equilibriad communication (oxenmq interface).
+///   - `quorumnet_port` -- The port for direct SN-to-SN xeqmlabsd communication (oxenmq interface).
 ///     Omitted if we have no uptime proof yet.
 ///   - `pubkey_ed25519` -- The service node's ed25519 public key for auxiliary services. Omitted if
 ///     we have no uptime proof yet.  Note that for newer registrations this will be the same as
@@ -2048,11 +2048,11 @@ struct GET_SERVICE_PRIVKEYS : NO_ARGS {
 ///   - `storage_server_reachable` -- True if this storage server is currently passing tests for the
 ///     purposes of SN node testing: true if the last test passed, or if it has been unreachable
 ///     for less than an hour; false if it has been failing tests for more than an hour (and thus
-///     is considered unreachable).  This field is omitted if the queried equilibriad is not a service
+///     is considered unreachable).  This field is omitted if the queried xeqmlabsd is not a service
 ///     node.
 ///   - `storage_server_first_unreachable` -- If the last test we received was a failure, this field
 ///     contains the timestamp when failures started.  Will be 0 if the last result was a success,
-///     and will be omitted if the node has not yet been tested since this equilibriad last restarted.
+///     and will be omitted if the node has not yet been tested since this xeqmlabsd last restarted.
 ///   - `storage_server_last_unreachable` -- The last time this service node's storage server failed
 ///     a ping test (regardless of whether or not it is currently failing). Will be omitted if it
 ///     has never failed a test since startup.
@@ -2189,12 +2189,12 @@ struct GET_SERVICE_NODE_STATUS : NO_ARGS {
 ///   - SN info (see below)
 ///   - common fields (see below)
 ///
-/// - `purges` -- array of service nodes being purged by equilibriad.  equilibriad service nodes issue purges
-///   when a service node is discovered in equilibriad that does *not* exist in the contract.  Such cases
+/// - `purges` -- array of service nodes being purged by xeqmlabsd.  xeqmlabsd service nodes issue purges
+///   when a service node is discovered in xeqmlabsd that does *not* exist in the contract.  Such cases
 ///   are typically only the result of some adverse network event (such as an L2 rollback) and serve
-///   to let equilibriad sync the network state with what exists in the contract.  Each element contains
+///   to let xeqmlabsd sync the network state with what exists in the contract.  Each element contains
 ///   fields:
-///   - `bls_pubkey` -- the BLS pubkey that exists in equilibriad, but not in the contract.
+///   - `bls_pubkey` -- the BLS pubkey that exists in xeqmlabsd, but not in the contract.
 ///   - SN info (see below)
 ///   - common fields (see below)
 ///
@@ -2329,8 +2329,8 @@ struct GET_ACCRUED_BATCHED_EARNINGS : GET_ACCRUED_REWARDS {
 /// - `omq_port` -- Storage server oxenmq port to include in uptime proofs.
 /// - `pubkey_ed25519` -- Service node Ed25519 pubkey for verifying that storage server is running
 ///   with the correct service node keys.
-/// - `error` -- If given and non-empty then this is an error message telling equilibriad to *not*
-///   submit an uptime proof and to report this error in the logs instead.  equilibriad won't send
+/// - `error` -- If given and non-empty then this is an error message telling xeqmlabsd to *not*
+///   submit an uptime proof and to report this error in the logs instead.  xeqmlabsd won't send
 ///   proofs until it gets another ping (without an error).
 ///
 /// Outputs:
@@ -2360,8 +2360,8 @@ struct STORAGE_SERVER_PING : RPC_COMMAND {
 /// - `version` -- Lokinet version (as an array of three integers).
 /// - `pubkey_ed25519` -- Service node Ed25519 pubkey for verifying that lokinet is running with
 ///   the correct service node keys.
-/// - `error` -- If given and non-empty then this is an error message telling equilibriad to *not*
-///   submit an uptime proof and to report this error in the logs instead.  equilibriad won't send
+/// - `error` -- If given and non-empty then this is an error message telling xeqmlabsd to *not*
+///   submit an uptime proof and to report this error in the logs instead.  xeqmlabsd won't send
 ///   proofs until it gets another ping (without an error).
 ///
 /// Outputs:
@@ -2484,7 +2484,7 @@ struct BLS_EXIT_LIQUIDATION_LIST : PUBLIC {
 ///   block.  If 0 or negative, then this is relative to the current top block height (as known by
 ///   *this* node).  That is: 0 returns the current value, -1 returns the balance from a block ago.
 ///   The default, if omitted, is -1: using -1 or -2 is recommended over 0 because lagging by a
-///   blocks helps avoid signing problems where the equilibriad where this RPC request is being made has
+///   blocks helps avoid signing problems where the xeqmlabsd where this RPC request is being made has
 ///   an updated block that is still being distributed across the network to some service nodes, and
 ///   so there is a higher likelihood that some service nodes will be unable to sign the balance for
 ///   the 0 height request.
@@ -2537,9 +2537,9 @@ struct BLS_REWARDS_REQUEST : PUBLIC {
 /// - if there is an associated main service node pubkey, that is the one to be exited/liquidated
 ///   and functions identically to passing that associated pubkey as `pubkey`.
 /// - if there is no associated primary pubkey found, *and* `liquidate` is true, then a BLS
-///   liquidation request will be performed for a equilibriad-missing BLS pubkey (to allow removing
-///   contract nodes that failed to make it to equilibriad for some reason).
-/// - otherwise, for exit (non-liquidation) mode, an error occurs: equilibriad-missing BLS keys can only
+///   liquidation request will be performed for a xeqmlabsd-missing BLS pubkey (to allow removing
+///   contract nodes that failed to make it to xeqmlabsd for some reason).
+/// - otherwise, for exit (non-liquidation) mode, an error occurs: xeqmlabsd-missing BLS keys can only
 ///   be removed through liquidation.
 ///
 /// Outputs:
@@ -2562,7 +2562,7 @@ struct BLS_EXIT_LIQUIDATION_REQUEST : PUBLIC {
 ///
 /// Obtains contract registration information (pubkeys and signatures) needed to register this
 /// service node with the L2 service node smart contract.  This request only obtains the required
-/// signatures, but does not affect the state of the current equilibriad, nor does it invalidate any
+/// signatures, but does not affect the state of the current xeqmlabsd, nor does it invalidate any
 /// previously issued registration signatures.
 ///
 /// Inputs:
@@ -2837,7 +2837,7 @@ void to_json(nlohmann::json& j, const ONS_OWNERS_TO_NAMES::response_entry& r);
 ///   not registered.
 ///
 /// Technical details: the returned value is encrypted using the name itself so that neither this
-/// equilibriad responding to the RPC request nor any other blockchain observers can (easily) obtain the
+/// xeqmlabsd responding to the RPC request nor any other blockchain observers can (easily) obtain the
 /// name of registered addresses or the registration details.  Thus, from a client's point of
 /// view, resolving an ONS record involves:
 ///

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -314,7 +314,7 @@ namespace {
     const char* USAGE_HELP("help [<command>]");
 
     //
-    // Equilibria
+    // XEQMLabs
     //
     const char* USAGE_REGISTER_SERVICE_NODE(
             "register_service_node [index=<N1>[,<N2>,...]] [<priority>] <operator cut> <address1> "
@@ -705,11 +705,11 @@ bool simple_wallet::spendkey(
         SCOPED_WALLET_UNLOCK();
 
         warn_msg_writer() << tr(
-                "NEVER give your Equilibria wallet private spend key (or seed phrase) to ANYONE else. "
-                "NEVER input your Equilibria private spend key (or seed phrase) into any software or "
+                "NEVER give your XEQMLabs wallet private spend key (or seed phrase) to ANYONE else. "
+                "NEVER input your XEQMLabs private spend key (or seed phrase) into any software or "
                 "website other than the OFFICIAL "
-                "Equilibria CLI or GUI wallets, downloaded directly from the Equilibria GitHub "
-                "(https://github.com/equilibria-core/) or compiled from source.");
+                "XEQMLabs CLI or GUI wallets, downloaded directly from the XEQMLabs GitHub "
+                "(https://github.com/xeqmlabs-core/) or compiled from source.");
         std::string confirm =
                 input_line(tr("Are you sure you want to access your private spend key?"), true);
         if (std::cin.eof() || !command_line::is_yes(confirm))
@@ -1981,38 +1981,38 @@ bool simple_wallet::net_stats(const std::vector<std::string>& args) {
 }
 
 bool simple_wallet::welcome(const std::vector<std::string>& args) {
-    message_writer() << tr("Welcome to Equilibria, the private cryptocurrency based on Monero");
+    message_writer() << tr("Welcome to XEQMLabs, the private cryptocurrency based on Monero");
     message_writer() << "";
     message_writer() << tr(
-            "Equilibria, like Bitcoin, is a cryptocurrency. That is, it is digital money.");
+            "XEQMLabs, like Bitcoin, is a cryptocurrency. That is, it is digital money.");
     message_writer() << tr(
-            "Unlike Bitcoin, your Equilibria transactions and balance stay private and are not visible "
+            "Unlike Bitcoin, your XEQMLabs transactions and balance stay private and are not visible "
             "to the world by default.");
     message_writer() << tr(
             "However, you have the option of making those available to select parties if you "
             "choose to.");
     message_writer() << "";
     message_writer() << tr(
-            "Equilibria protects your privacy on the blockchain, and while Equilibria strives to improve all "
+            "XEQMLabs protects your privacy on the blockchain, and while XEQMLabs strives to improve all "
             "the time,");
     message_writer() << tr(
-            "no privacy technology can be 100% perfect, Monero and consequently Equilibria included.");
+            "no privacy technology can be 100% perfect, Monero and consequently XEQMLabs included.");
     message_writer() << tr(
-            "Equilibria cannot protect you from malware, and it may not be as effective as we hope "
+            "XEQMLabs cannot protect you from malware, and it may not be as effective as we hope "
             "against powerful adversaries.");
     message_writer() << tr(
-            "Flaws in Equilibria may be discovered in the future, and attacks may be developed to peek "
+            "Flaws in XEQMLabs may be discovered in the future, and attacks may be developed to peek "
             "under some");
     message_writer() << tr(
-            "of the layers of privacy Equilibria provides. Be safe and practice defense in depth.");
+            "of the layers of privacy XEQMLabs provides. Be safe and practice defense in depth.");
     message_writer() << "";
     message_writer() << tr(
-            "Welcome to Equilibria and financial privacy. For more information, see https://oxen.io");
+            "Welcome to XEQMLabs and financial privacy. For more information, see https://oxen.io");
     return true;
 }
 
 bool simple_wallet::version(const std::vector<std::string>& args) {
-    message_writer() << "Equilibria '" << OXEN_RELEASE_NAME << "' (v" << OXEN_VERSION_FULL << ")";
+    message_writer() << "XEQMLabs '" << OXEN_RELEASE_NAME << "' (v" << OXEN_VERSION_FULL << ")";
     return true;
 }
 
@@ -2675,12 +2675,12 @@ simple_wallet::simple_wallet() :
  refresh-from-block-height [n]
    Set the height before which to ignore blocks.
  segregate-pre-fork-outputs <1|0>
-   Set this if you intend to spend outputs on both Equilibria AND a key reusing fork.
+   Set this if you intend to spend outputs on both XEQMLabs AND a key reusing fork.
  key-reuse-mitigation2 <1|0>
-   Set this if you are not sure whether you will spend on a key reusing Equilibria fork later.
+   Set this if you are not sure whether you will spend on a key reusing XEQMLabs fork later.
  subaddress-lookahead <major>:<minor>
    Set the lookahead sizes for the subaddress hash table.
-   Set this if you are not sure whether you will spend on a key reusing Equilibria fork later.
+   Set this if you are not sure whether you will spend on a key reusing XEQMLabs fork later.
  segregation-height <n>
    Set to the height of a key reusing fork you want to use, 0 to use default.
  ignore-outputs-above <amount>
@@ -2958,7 +2958,7 @@ Pending or Failed: "failed"|"pending",  "out", Lock, Checkpointed, Time, Amount*
             "mms signer",
             [this](const auto& x) { return mms(x); },
             tr(USAGE_MMS_SIGNER),
-            tr("Set or modify authorized signer info (single-word label, transport address, Equilibria "
+            tr("Set or modify authorized signer info (single-word label, transport address, XEQMLabs "
                "address), or list all signers"));
     m_cmd_binder.set_handler(
             "mms list",
@@ -3127,7 +3127,7 @@ Pending or Failed: "failed"|"pending",  "out", Lock, Checkpointed, Time, Amount*
     m_cmd_binder.set_cancel_handler([this] { return on_cancelled_command(); });
 
     //
-    // Equilibria
+    // XEQMLabs
     //
     m_cmd_binder.set_handler(
             "register_service_node",
@@ -3187,14 +3187,14 @@ Pending or Failed: "failed"|"pending",  "out", Lock, Checkpointed, Time, Amount*
             "ons_by_owner",
             [this](const auto& x) { return ons_by_owner(x); },
             tr(USAGE_ONS_BY_OWNER),
-            tr("Query the Equilibria Name Service names that the keys have purchased. If no keys are "
+            tr("Query the XEQMLabs Name Service names that the keys have purchased. If no keys are "
                "specified, it defaults to the current wallet."));
 
     m_cmd_binder.set_handler(
             "ons_lookup",
             [this](const auto& x) { return ons_lookup(x); },
             tr(USAGE_ONS_LOOKUP),
-            tr("Query the ed25519 public keys that own the Equilibria Name System names."));
+            tr("Query the ed25519 public keys that own the XEQMLabs Name System names."));
 
     m_cmd_binder.set_handler(
             "ons_make_update_mapping_signature",
@@ -3452,10 +3452,10 @@ void simple_wallet::print_seed(const epee::wipeable_string& seed) {
                                         m_wallet->multisig() ? tr("string") : tr("25 words"));
 
     warn_msg_writer() << tr(
-            "NEVER give your Equilibria wallet seed to ANYONE else. NEVER input your Equilibria "
-            "wallet seed into any software or website other than the OFFICIAL Equilibria CLI or GUI "
+            "NEVER give your XEQMLabs wallet seed to ANYONE else. NEVER input your XEQMLabs "
+            "wallet seed into any software or website other than the OFFICIAL XEQMLabs CLI or GUI "
             "wallets, "
-            "downloaded directly from the Equilibria GitHub (https://github.com/equilibria-core/) or compiled "
+            "downloaded directly from the XEQMLabs GitHub (https://github.com/xeqmlabs-core/) or compiled "
             "from source.");
     std::string confirm = input_line(tr("Are you sure you want to access your wallet seed?"), true);
     if (std::cin.eof() || !command_line::is_yes(confirm))
@@ -4066,7 +4066,7 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm) {
             message_writer(fmt::terminal_color::yellow)
                     << tr("Using your own without SSL exposes your RPC traffic to monitoring");
         message_writer(fmt::terminal_color::yellow)
-                << tr("You are strongly encouraged to connect to the Equilibria network using your own "
+                << tr("You are strongly encouraged to connect to the XEQMLabs network using your own "
                       "daemon");
         message_writer(fmt::terminal_color::yellow)
                 << tr("If you or someone you trust are operating this daemon, you can use "
@@ -4091,7 +4091,7 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm) {
 
     if (welcome)
         message_writer(fmt::terminal_color::yellow)
-                << tr("If you are new to Equilibria, type \"welcome\" for a brief overview.");
+                << tr("If you are new to XEQMLabs, type \"welcome\" for a brief overview.");
 
     m_last_activity_time = time(NULL);
     return true;
@@ -5750,7 +5750,7 @@ void simple_wallet::check_for_inactivity_lock(bool user) {
             message_writer() << R"(
       ...........
     ...............
-  ....OOOOOOOOOOO....   Your Equilibria Wallet was locked to
+  ....OOOOOOOOOOO....   Your XEQMLabs Wallet was locked to
  .......OOOOOOO.......  protect you while you were away.
  ..........O..........
  .......OOOOOOO.......  (Use `set inactivity-lock-timeout 0`
@@ -6736,7 +6736,7 @@ bool simple_wallet::ons_buy_mapping(std::vector<std::string> args) {
         info.is_subaddress = m_current_subaddress_account != 0;
         dsts.push_back(info);
 
-        std::cout << std::endl << tr("Buying Equilibria Name System Record") << std::endl << std::endl;
+        std::cout << std::endl << tr("Buying XEQMLabs Name System Record") << std::endl << std::endl;
         if (*type == ons::mapping_type::session)
             std::cout << "Session Name: {}"_format(name) << std::endl;
         else if (*type == ons::mapping_type::wallet)
@@ -6828,7 +6828,7 @@ bool simple_wallet::ons_renew_mapping(std::vector<std::string> args) {
         info.is_subaddress = m_current_subaddress_account != 0;
         dsts.push_back(info);
 
-        std::cout << "\n" << tr("Renew Equilibria Name System Record") << "\n\n";
+        std::cout << "\n" << tr("Renew XEQMLabs Name System Record") << "\n\n";
         if (ons::is_lokinet_type(type))
             std::cout << "Lokinet Name:  {}"_format(name) << "\n";
         else
@@ -6935,7 +6935,7 @@ bool simple_wallet::ons_update_mapping(std::vector<std::string> args) {
         info.is_subaddress = m_current_subaddress_account != 0;
         dsts.push_back(info);
 
-        std::cout << std::endl << tr("Updating Equilibria Name System Record") << std::endl << std::endl;
+        std::cout << std::endl << tr("Updating XEQMLabs Name System Record") << std::endl << std::endl;
         if (type == ons::mapping_type::session)
             std::cout << "Session Name:     {}"_format(name) << std::endl;
         else if (ons::is_lokinet_type(type))
@@ -10089,8 +10089,8 @@ int main(int argc, char* argv[]) {
             argv,
             "xeq-wallet-cli [--wallet-file=<filename>|--generate-new-wallet=<filename>] "
             "[<COMMAND>]",
-            sw::tr("This is the command line Equilibria wallet. It needs to connect to a Equilibria\ndaemon to "
-                   "work correctly.\n\nWARNING: Do not reuse your Equilibria keys on a contentious fork, "
+            sw::tr("This is the command line XEQMLabs wallet. It needs to connect to a XEQMLabs\ndaemon to "
+                   "work correctly.\n\nWARNING: Do not reuse your XEQMLabs keys on a contentious fork, "
                    "doing so will harm your privacy.\n Only consider reusing your key on a "
                    "contentious fork if the fork has key reuse mitigations built in."),
             desc_params,

--- a/src/wallet/wallet_args.cpp
+++ b/src/wallet/wallet_args.cpp
@@ -206,7 +206,7 @@ std::pair<std::optional<boost::program_options::variables_map>, bool> main(
     if (!command_line::is_arg_defaulted(vm, arg_max_concurrency))
         tools::set_max_concurrency(command_line::get_arg(vm, arg_max_concurrency));
 
-    print("Equilibria '{}' (v{})\n"_format(OXEN_RELEASE_NAME, OXEN_VERSION_FULL));
+    print("XEQMLabs '{}' (v{})\n"_format(OXEN_RELEASE_NAME, OXEN_VERSION_FULL));
 
     if (!command_line::is_arg_defaulted(vm, arg_log_level))
         log::info(logcat, "Setting log level = {}", command_line::get_arg(vm, arg_log_level));


### PR DESCRIPTION
Renames all user-facing strings, filenames, and seed node references from Equilibria/equilibria to XEQMLabs/xeqm. Also renames binaries to xeqm-d, xeqm-wallet, xeqm-rpc via CMakeLists.txt.