### PR TITLE
Brand wallet version output as XEQMLabs

### DIFF
--- a/src/wallet/wallet_args.cpp
+++ b/src/wallet/wallet_args.cpp
@@ -145,7 +145,7 @@ std::pair<std::optional<boost::program_options::variables_map>, bool> main(
         bool help = command_line::get_arg(vm, command_line::arg_help);
         bool version = command_line::get_arg(vm, command_line::arg_version);
         if (help or version) {
-            print("Oxen '{}' (v{})\n"_format(OXEN_RELEASE_NAME, OXEN_VERSION_FULL));
+            print("XEQMLabs '{}' (v{})\n"_format(OXEN_RELEASE_NAME, OXEN_VERSION_FULL));
 
             if (help) {
                 print(


### PR DESCRIPTION
xeqm-d      = XEQMLabs 'Ragnarok'
xeqm-wallet = Oxen 'Ragnarok'
xeqm-rpc    = Oxen 'Ragnarok'

The wallet/RPC branding is still pulling from an Oxen-specific string that are not descriptive to the user. 