### PR TITLE
fix: hold m_sn_mutex across sql_db->add_block to prevent heap corruption

### DIFF
--- a/src/cryptonote_core/service_node_list.cpp
+++ b/src/cryptonote_core/service_node_list.cpp
@@ -3208,6 +3208,14 @@ void service_node_list::block_add(
     ZoneScoped;
     block_add_result result = {};
 
+    // Hold m_sn_mutex across all m_state reads/writes in this function,
+    // including the sql_db->add_block() call below which previously ran after
+    // the inner lock was released — exposing m_state to concurrent mutation
+    // during the SQL write and producing intermittent heap corruption around
+    // v19+ pulse blocks. m_sn_mutex is recursive so nested locking in process_block
+    // and friends remains safe.
+    std::lock_guard lock(m_sn_mutex);
+
     if (block.major_version < hf::hf9_service_nodes) {
         m_state.height = block.get_height();
     } else {
@@ -3219,7 +3227,6 @@ void service_node_list::block_add(
                     "{})"_format(m_state.height, blockchain.sqlite_db().height));
         }
 
-        std::lock_guard lock(m_sn_mutex);
         result = process_block(block, txs);
         if (!rescan || !rescan->skip_verify)
             verify_block(block, false /*alt_block*/, checkpoint);


### PR DESCRIPTION
  ## Summary
`service_node_list::block_add()` released `m_sn_mutex` before calling `sql_db->add_block(block, m_state, result,
  rescan)`, leaving `m_state` exposed to concurrent mutation during the SQL write. This produced intermittent heap
  corruption that surfaced as `STATUS_HEAP_CORRUPTION` (`0xC0000374`) on Windows during initial sync, consistently
  around the v19 hard fork blocks (~16414 on mainnet).

  The fix moves the `std::lock_guard lock(m_sn_mutex)` from inside the `else` block to the top of the function, widening
   its scope to cover the SQL DB call. `m_sn_mutex` is `std::recursive_mutex`, so nested locks inside `process_block`
  and friends remain safe.

  ## Repro (before the fix)

  xeqm-d --data-dir  --log-level 1

  Sync from block 0 on mainnet. Daemon crashes intermittently around block 16414 with exit code `3221226356`
  (`0xC0000374`). Last log line is always immediately after a `+++++ PULSE BLOCK SUCCESSFULLY ADDED` entry.

## Diff

  Three-line move of the existing `lock_guard` declaration. No new locks introduced. No new code paths. No behavior
  change other than holding the lock for the additional ~milliseconds the SQL write takes.