### PR TITLE
fix: prevent fresh service nodes from being permanently deregistered

### DIFF
--- a/src/cryptonote_core/service_node_quorum_cop.cpp
+++ b/src/cryptonote_core/service_node_quorum_cop.cpp
@@ -191,24 +191,31 @@ service_node_test_results quorum_cop::check_service_node(
         }
     }
 
-    // These checks will not be performed when a node is being considered for recommission
+    // These checks will not be performed when a node is being considered for recommission.
+    // Participation-window guard: require a full QUORUM_VOTE_CHECK_COUNT window of votes
+    // before a failure count can produce a verdict (otherwise fresh nodes get marked failing
+    // before the window is even populated).
     if (!info.is_decommissioned()) {
         if (check_checkpoint_obligation &&
+            checkpoint_participation.size() >= checkpoint_participation.max_size() &&
             checkpoint_participation.failures() > CHECKPOINT_MAX_MISSABLE_VOTES) {
             log::info(logcat, "Service Node: {}, failed checkpoint obligation check", pubkey);
             result.checkpoint_participation = false;
         }
 
-        if (pulse_participation.failures() > PULSE_MAX_MISSABLE_VOTES) {
+        if (pulse_participation.size() >= pulse_participation.max_size() &&
+            pulse_participation.failures() > PULSE_MAX_MISSABLE_VOTES) {
             log::info(logcat, "Service Node: {}, failed pulse obligation check", pubkey);
             result.pulse_participation = false;
         }
 
-        if (timestamp_participation.failures() > TIMESTAMP_MAX_MISSABLE_VOTES) {
+        if (timestamp_participation.size() >= timestamp_participation.max_size() &&
+            timestamp_participation.failures() > TIMESTAMP_MAX_MISSABLE_VOTES) {
             log::info(logcat, "Service Node: {}, failed timestamp obligation check", pubkey);
             result.timestamp_participation = false;
         }
-        if (timesync_status.failures() > TIMESYNC_MAX_UNSYNCED_VOTES) {
+        if (timesync_status.size() >= timesync_status.max_size() &&
+            timesync_status.failures() > TIMESYNC_MAX_UNSYNCED_VOTES) {
             log::info(logcat, "Service Node: {}, failed timesync obligation check", pubkey);
             result.timesync_status = false;
         }

--- a/src/cryptonote_core/service_node_rules.h
+++ b/src/cryptonote_core/service_node_rules.h
@@ -55,7 +55,7 @@ constexpr uint16_t pulse_validator_bit_mask() {
 // decommission time: the first quorum test after the credit expires determines whether the server
 // gets recommissioned or decommissioned).
 inline constexpr auto DECOMMISSION_CREDIT_PER_DAY = 24 * 60min / 30;  // 24h credit per 30 days
-inline constexpr auto DECOMMISSION_INITIAL_CREDIT = 2h;
+inline constexpr auto DECOMMISSION_INITIAL_CREDIT = 12h;
 inline constexpr auto DECOMMISSION_MAX_CREDIT = 48h;
 inline constexpr auto DECOMMISSION_MINIMUM = 2h;
 


### PR DESCRIPTION
## Summary

  Fixes #20 — fresh service nodes were getting permanently deregistered within hours of registration because (a)
  `DECOMMISSION_INITIAL_CREDIT` equals `DECOMMISSION_MINIMUM` at 2h, leaving zero buffer above the deregistration
  threshold, and (b) the participation-failure threshold can be tripped before the participation history window is even
  populated, so a fresh node accumulates a "failing" verdict during its first few quorums while still coming online.

  Two narrowly-scoped changes:

  ### 1. `DECOMMISSION_INITIAL_CREDIT`: 2h → 12h (`service_node_rules.h`)

  The primary recommendation from #20. On XEQM's 1-minute chain, 2h = 120 blocks, which is identical to
  `DECOMMISSION_MINIMUM`. A fresh node decommissioned in its first few hours has 0 buffer above the dereg threshold. 12h
   gives operators a real window to react.

  ### 2. Participation-window guard (`service_node_quorum_cop.cpp::check_service_node`)

  Require `participation_history.size() >= participation_history.max_size()` before applying the failure-count check on
  all four participation types (checkpoint, pulse, timestamp, timesync). A node's history is a circular buffer of
  `QUORUM_VOTE_CHECK_COUNT` (8) entries; on XEQM that fills in ~8 minutes. The existing threshold check (`failures() >
  MAX_MISSABLE_VOTES`) can fire as soon as 5 entries exist, well before the window is meaningfully populated.

  With this guard, behavior for established nodes is identical — once the buffer is full, the check operates the same as
   before. For fresh nodes, the failure verdict is suppressed until the buffer has been fully populated, giving them a
  full window's worth of votes before they can be marked as failing participation obligations.

  ### Combined effect on the snode1 case from #20

  | Block | Event | Before | After |
  |---|---|---|---|
  | 13256 | Registration | credit = 120 | credit = 720 |
  | ~13260 | First few quorum tests (partial history) | can fail at 5/8 failures | suppressed until 8/8 |
  | ~13831 | Decommission | credit = 139 (≥ MIN ✓) | credit = 739 (≥ MIN ✓) |
  | ~13970 | Dereg (139 blocks post-decom) | yes — fresh node lost | no — 739 blocks of recovery |

  ### Backwards compatibility

  `DECOMMISSION_INITIAL_CREDIT` only affects newly-registered nodes after deployment; existing nodes retain their
  accumulated credits. The participation-window guard does not affect established nodes whose buffers are already full.