### PR TITLE
build: ship xeqm-mdb_copy / xeqm-mdb_stat in release packages

### DIFF
--- a/.github/workflows/build-core-binaries.yml
+++ b/.github/workflows/build-core-binaries.yml
@@ -101,7 +101,7 @@ jobs:
           set -e
           ALLOW='^[[:space:]]*(linux-vdso\.so|libc\.so|libstdc\+\+\.so|libgcc_s\.so|libm\.so|libpthread\.so|libdl\.so|librt\.so|/lib(64)?/ld-linux)'
           fail=0
-          for bin in xeqm-d xeqm-wallet xeqm-rpc; do
+          for bin in xeqm-d xeqm-wallet xeqm-rpc xeqm-mdb_copy xeqm-mdb_stat; do
             echo "=== $bin ==="
             ldd "build/bin/$bin"
             unexpected=$(ldd "build/bin/$bin" | awk '{print $1}' | grep -Ev "$ALLOW" || true)
@@ -133,6 +133,8 @@ jobs:
           cp build/bin/xeqm-d "$PKG/"
           cp build/bin/xeqm-wallet "$PKG/"
           cp build/bin/xeqm-rpc "$PKG/"
+          cp build/bin/xeqm-mdb_copy "$PKG/"
+          cp build/bin/xeqm-mdb_stat "$PKG/"
           chmod +x "$PKG"/*
 
           {
@@ -141,7 +143,9 @@ jobs:
             printf "Included:\\n"
             printf "  xeqm-d\\n"
             printf "  xeqm-wallet\\n"
-            printf "  xeqm-rpc\\n\\n"
+            printf "  xeqm-rpc\\n"
+            printf "  xeqm-mdb_copy\\n"
+            printf "  xeqm-mdb_stat\\n\\n"
             printf "Version output:\\n\\n"
             ./build/bin/xeqm-d --version
             ./build/bin/xeqm-wallet --version
@@ -285,6 +289,8 @@ jobs:
           cp "$BIN_DIR/xeqm-d.exe" "$PKG/"
           cp "$BIN_DIR/xeqm-wallet.exe" "$PKG/"
           cp "$BIN_DIR/xeqm-rpc.exe" "$PKG/"
+          cp "$BIN_DIR/xeqm-mdb_copy.exe" "$PKG/"
+          cp "$BIN_DIR/xeqm-mdb_stat.exe" "$PKG/"
 
           find "$BIN_DIR" -maxdepth 1 -type f -name '*.dll' -exec cp {} "$PKG/" \; || true
 
@@ -294,7 +300,9 @@ jobs:
             printf "Included:\n"
             printf "  xeqm-d.exe\n"
             printf "  xeqm-wallet.exe\n"
-            printf "  xeqm-rpc.exe\n\n"
+            printf "  xeqm-rpc.exe\n"
+            printf "  xeqm-mdb_copy.exe\n"
+            printf "  xeqm-mdb_stat.exe\n\n"
             printf "Version output:\n\n"
             wine "$BIN_DIR/xeqm-d.exe" --version || true
             wine "$BIN_DIR/xeqm-wallet.exe" --version || true
@@ -442,7 +450,7 @@ jobs:
         shell: bash
         run: |
           cmake --build build-macos-arm64 \
-            --target daemon simplewallet wallet_rpc_server \
+            --target daemon simplewallet wallet_rpc_server mdb_copy mdb_stat \
             --parallel "$(sysctl -n hw.ncpu)"
 
       - name: Bundle Homebrew dylibs into binaries
@@ -500,8 +508,10 @@ jobs:
           cp build-macos-arm64/bin/xeqm-d "$PKG/"
           cp build-macos-arm64/bin/xeqm-wallet "$PKG/"
           cp build-macos-arm64/bin/xeqm-rpc "$PKG/"
+          cp build-macos-arm64/bin/xeqm-mdb_copy "$PKG/"
+          cp build-macos-arm64/bin/xeqm-mdb_stat "$PKG/"
           cp -R build-macos-arm64/bin/libs "$PKG/"
-          chmod +x "$PKG"/xeqm-d "$PKG"/xeqm-wallet "$PKG"/xeqm-rpc
+          chmod +x "$PKG"/xeqm-d "$PKG"/xeqm-wallet "$PKG"/xeqm-rpc "$PKG"/xeqm-mdb_copy "$PKG"/xeqm-mdb_stat
 
           {
             printf "XEQM Core macOS ARM64 binaries\n\n"
@@ -510,6 +520,8 @@ jobs:
             printf "  xeqm-d\n"
             printf "  xeqm-wallet\n"
             printf "  xeqm-rpc\n"
+            printf "  xeqm-mdb_copy\n"
+            printf "  xeqm-mdb_stat\n"
             printf "  libs/  (bundled runtime dylibs — keep next to the binaries)\n\n"
             printf "Version output:\n\n"
             ./build-macos-arm64/bin/xeqm-d --version

--- a/external/db_drivers/liblmdb/CMakeLists.txt
+++ b/external/db_drivers/liblmdb/CMakeLists.txt
@@ -55,3 +55,18 @@ if (BUILD_GUI_DEPS)
         ARCHIVE DESTINATION ${lib_folder}
         LIBRARY DESTINATION ${lib_folder})
 endif()
+
+# LMDB hot-backup / inspection tools, built from this exact vendored source so
+# their on-disk format always matches xeqm-d's database. A stock distro mdb_copy
+# (e.g. lmdb-utils) fails against this fork with MDB_VERSION_MISMATCH; linking the
+# `lmdb` target above means these tools inherit the same compile definitions
+# (MDB_VL32 on 32-bit builds, etc.) automatically on every platform. Shipped as
+# xeqm-mdb_copy / xeqm-mdb_stat so operators can take consistent live snapshots:
+#   xeqm-mdb_copy -c <data-dir>/lmdb <dest>
+foreach(_lmdb_tool mdb_copy mdb_stat)
+  add_executable(${_lmdb_tool} ${_lmdb_tool}.c)
+  target_link_libraries(${_lmdb_tool} PRIVATE lmdb Threads::Threads)
+  set_target_properties(${_lmdb_tool} PROPERTIES
+    OUTPUT_NAME "xeqm-${_lmdb_tool}"
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+endforeach()


### PR DESCRIPTION
## Summary

Build the LMDB hot-backup/inspection tools (`mdb_copy`, `mdb_stat`) from our **in-tree vendored liblmdb** and ship them in every release package as `xeqm-mdb_copy` / `xeqm-mdb_stat`.

## Why

`xeqm-d` uses a vendored LMDB fork (reports `LMDB 0.9.70`). A stock distro `mdb_copy` (e.g. `lmdb-utils`, LMDB 0.9.31) **cannot open our database** — it fails with `MDB_VERSION_MISMATCH` (-30794). The only reliable tool is one built from *our exact* LMDB source.

This matters because `mdb_copy -c` takes a **consistent, compacted, read-transaction snapshot** of a live env. A plain `cp` of a running LMDB can be torn: without a read txn pinning the snapshot, the daemon can reclaim/overwrite free pages the copy already walked. That's exactly the risk for the **chain bootstrap** (`bootstrap.xeqmlabs.com`), which operators restore during outages — when correctness matters most.

## How

- **CMake** (`external/db_drivers/liblmdb/CMakeLists.txt`): add `mdb_copy`/`mdb_stat` executables that **link the existing `lmdb` target**. They inherit its exact compile definitions (`MDB_VL32` on 32-bit, etc.) automatically, so the tools are **format-matched to the daemon on every platform and every release** — no manual flag management. Output as `xeqm-mdb_copy` / `xeqm-mdb_stat` into `build/bin/`.
- **Packaging**: copy both into the Ubuntu, Windows, and macOS release packages + README; add them to the macOS explicit `--target` list (Linux/Windows `make` builds all targets); add them to the Linux portable-linking gate.

## Alpha validation (operator infra)

Built from the **v1.0.5 (`c17302b`)** source matching our deployed pubnode and tested on `pn-1` against the **live** daemon DB:
- `xeqm-mdb_copy -c /opt/xeqm/data/lmdb …` → opens cleanly (no version mismatch), produces a valid env (`xeqm-mdb_stat -e` confirms), ~6% smaller via compaction (492 M → 463 M raw; 388 → 379 MB compressed).
- Opens the live env **read-only** — safe alongside the running daemon.
- Already wired into the bootstrap generator on pn-1 as `mdb_copy -c` with a `cp -a` fallback (so the job can never hard-break if the tool is ever missing/incompatible).

## Notes for reviewers / to confirm in CI

- New targets land in `build/bin/` via explicit `RUNTIME_OUTPUT_DIRECTORY`; please confirm the Windows static build emits `xeqm-mdb_copy.exe` into the same `BIN_DIR` the package step discovers.
- macOS: these tools link only the static `lmdb` + libSystem (no Homebrew dylibs), so they're intentionally **not** in the `dylibbundler` loop. Please confirm `otool -L` shows no Homebrew paths.
- Naming `xeqm-mdb_copy` avoids collision with any system `lmdb-utils`.

## Follow-up (separate, operator side)

Once a release ships these in the daemon bin dir, point the bootstrap generator's `MDB_COPY` at `/opt/xeqm-pubnode/bin/xeqm-mdb_copy` so it auto-updates in lockstep with the daemon on every SUDS upgrade.

---

Handing this to the core team to own: alpha-validated on operator infrastructure; proposing for your review → daemon rebuild + experienced-operator beta → production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
