### PR TITLE
fix: remove blockchain lock from get_tail_id() to prevent OMQ worker starvation

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1194,7 +1194,10 @@ bool Blockchain::reset_and_set_genesis_block(const block& b) {
 std::pair<uint64_t, crypto::hash> Blockchain::get_tail_id() const {
     log::trace(logcat, "Blockchain::{}", __func__);
     std::pair<uint64_t, crypto::hash> result;
-    std::unique_lock lock{*this};
+    // LMDB provides MVCC read-consistency; the blockchain mutex is not needed
+    // for a top-block read. Holding it here blocks OMQ worker threads (pulse,
+    // p2p handshake) behind long write-path LMDB locks, starving quorumnet.
+    // See: XEQMLabs/xeqm-core#35
     result.second = m_db->top_block_hash(&result.first);
     return result;
 }


### PR DESCRIPTION
## Summary

- Removes the `std::unique_lock` from `Blockchain::get_tail_id()` — a read-only LMDB query that does not need the blockchain mutex
- Fixes the confirmed daemon wedge where pulse OMQ workers stall behind long write-path locks, causing quorumnet probe timeouts and decommission

## Root Cause

`pulse::check_state` dispatches as an OMQ job. Inside the job it calls `wait_for_round()` → `Blockchain::get_tail_id()`, which previously took an exclusive lock on the blockchain `std::recursive_mutex`. When another thread holds that mutex during a long LMDB write (block add, initial sync, resync), the pulse OMQ worker blocks indefinitely. With the worker slot occupied, quorumnet probes go unanswered.

The same lock contention hits the p2p `connections_maker` path (`get_payload_sync_data` → `get_tail_id()`), stalling peer handshakes during block processing.

## Evidence

Stack dump from a live wedge (seed-3 snode2, July 2026), closes #38:

```
Thread 29 "pulse" — blocked at:
  pthread_mutex_lock(0x5861b1d187a0)        <- blockchain mutex
  Blockchain::get_tail_id (blockchain.cpp:1197)
  pulse_impl::wait_for_round (pulse.cpp:1487)
  pulse_impl::check_state (pulse.cpp:2291)
  pulse::pulse::operator() (pulse.cpp:2340)
  oxenmq::Job::run_job (batch.h:306)
  oxenmq::OxenMQ::worker_thread (worker.cpp:117)

Thread 20 "connections_maker" — also blocked at same mutex:
  Blockchain::get_tail_id (blockchain.cpp:1197)
  t_cryptonote_protocol_handler::get_payload_sync_data
  node_server::do_handshake_with_peer (net_node.inl:988)

Mutex holder (LWP 2226312): __wait_on_buffer / pread64  <- LMDB disk I/O
```

## The Fix

LMDB uses MVCC: read transactions see a consistent snapshot without requiring an application-level lock. `top_block_hash()` is a pure LMDB read — it opens a read transaction and returns the tip hash; no in-memory blockchain state is involved.

Callers inside `blockchain.cpp` that already hold the blockchain lock before calling `get_tail_id()` are unaffected (the `std::recursive_mutex` makes the re-acquire a no-op). The external callers — pulse and p2p handshake — do not hold the lock and do not need per-call consistency with in-memory state.

```diff
-    std::unique_lock lock{*this};
+    // LMDB provides MVCC read-consistency; the blockchain mutex is not needed
+    // for a top-block read. Holding it here blocks OMQ worker threads (pulse,
+    // p2p handshake) behind long write-path LMDB locks, starving quorumnet.
+    // See: XEQMLabs/xeqm-core#38
```

## Test Plan

- [ ] Rebuild daemon from this branch
- [ ] Deploy to seed nodes (2 SNs each, confirmed wedge-prone)
- [ ] Soak 24h — verify no `daemon_wedge_capture` alarms and no decommission events
- [ ] Verify all remaining `get_tail_id()` callers in blockchain.cpp already hold the lock (recursive mutex makes re-acquire safe)

## Related

- Closes #38
- See blockchain.h:1324 TODO comment about reader/writer lock — converting `m_blockchain_lock` to `std::shared_mutex` is the longer-term fix; this PR is the minimal targeted patch for the confirmed wedge path
