### PR TITLE
fix: demote obligations quorum miss to debug during HF transitions

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4676,8 +4676,15 @@ bool Blockchain::check_tx_inputs(
             auto quorum = service_node_list.get_quorum(
                     service_nodes::quorum_type::obligations, state_change.block_height);
             if (!quorum) {
-                log::error(
-                        logverify, "could not get obligations quorum for recent state change tx");
+                // Not an internal error: during a hard fork transition, peers still on the
+                // pre-fork chain broadcast state_change txs referencing heights that fall
+                // outside our canonical state_history window.  Reject silently at debug level.
+                log::debug(
+                        logverify,
+                        "No obligations quorum at height {} (current tip {}); tx likely from a "
+                        "peer on a stale or forked chain — rejecting",
+                        state_change.block_height,
+                        get_current_blockchain_height());
                 return false;
             }
 


### PR DESCRIPTION
## Problem

After HF21 activated at block 99,000, pn-* service nodes logged ~420 error entries per 18 hours:

```
[verify:error|cryptonote_core/blockchain.cpp:4683] could not get obligations quorum for recent state change tx
```

This was also reported by community operators (e.g. BigSlim) as misleading noise suggesting their nodes had a software bug.

## Root Cause

During a hard fork transition, peers **still on the pre-fork chain** broadcast `state_change` txs referencing block heights that fall outside the current node's canonical state_history window (`HISTORY_RECENT_KEEP_WINDOW = 65 blocks`). `get_quorum()` returns null for those heights, the tx is correctly rejected, but `log::error` was used — implying an internal code failure.

This is **not a bug** in the rejecting node. The key invariant:

- Valid `state_change` txs always reference heights within `VOTE_LIFETIME` (60 blocks) ≤ `keep_quorum_offset` (65), so they always find a quorum.
- Any tx that triggers the null-quorum path has a `block_height` outside the history window — definitionally from a stale/forked peer.

## Why pn-* nodes were affected and Wayland's server was not

Wayland's server  has 20 colocated snodes forming a dense local peer mesh. They reach quorum among themselves and never receive pre-HF21 forked-chain txs from external stale peers. pn-* nodes (2–3 snodes each) have sparse external peers and receive stale txs constantly until old peers reconnect on the canonical chain.

## Fix

- Demote `log::error` → `log::debug` at `blockchain.cpp:4683`
- Improve message to include heights and explain the cause
- Add comment distinguishing expected (stale peer) from a genuine bug (in-range height with missing quorum — which should never happen)

## Testing

Verified on pn-* snodes after restart: error log completely absent; nodes continue to reject stale-fork txs correctly (tx pool not poisoned, chain not affected).