### PR TITLE
fix: sentinel static_asserts to catch hf enum-shift regressions (issue #32)

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -305,6 +305,15 @@ namespace feature {
     constexpr auto ETH_TRANSITION = hf::hf20_eth_transition;
     constexpr auto ETH_BLS = hf::hf21_eth;
     constexpr auto SN_PK_IS_ED25519 = hf::hf21_eth;
+
+    // Sentinels: inserting a new hf entry before hf20_eth_transition or hf21_eth
+    // silently shifts every >= comparison against these aliases (~40 sites for ETH_BLS).
+    // Root cause of HF20 mainnet stall (issues #30 / #32). If intentionally renumbering,
+    // audit every ETH_TRANSITION/ETH_BLS callsite first, then update these values.
+    static_assert(static_cast<uint8_t>(hf::hf20_eth_transition) == 22,
+            "hf20_eth_transition shifted -- audit feature::ETH_TRANSITION callsites (issue #32)");
+    static_assert(static_cast<uint8_t>(hf::hf21_eth) == 23,
+            "hf21_eth shifted -- audit feature::ETH_BLS / SN_PK_IS_ED25519 callsites (issue #32)");
 }  // namespace feature
 
 enum class network_type : uint8_t {


### PR DESCRIPTION
## Summary

Pins the integer values of `hf20_eth_transition` (22) and `hf21_eth` (23) with `static_assert` sentinels next to the `feature::` alias definitions in `cryptonote_config.h`.

**Problem:** Any `hf` enum insertion before these entries silently shifts every `>=` comparison against the corresponding alias. `ETH_BLS` has ~40 such sites across block validation, miner_tx construction, SN list updates, and serialization — a silent shift would be much harder to root-cause than the HF20 stall was.

The existing `static_assert(hf_max == 24)` only catches appended entries; it does not catch insertions before existing entries.

**Fix:** Two `static_assert` lines. Zero runtime cost, no behavior change. Forces any author who inserts a new HF entry before `hf20_eth_transition` or `hf21_eth` to acknowledge the audit obligation before CI lets the change land.

## Closes

Closes #32

## Related

- Issue #30 / PR #31 — HF20 mainnet stall caused by exactly this bug class
- The enum shift that caused #30: PR #28/#29 inserted `hf20_governance_payouts_fix` before `hf20_eth_transition`

## Test plan

- [ ] Build succeeds with current enum ordering (sentinels pass at 22/23)
- [ ] Manually shift the enum to verify the assert fires with the expected message